### PR TITLE
remove keys() in count_groups

### DIFF
--- a/union_find/unionfind.py
+++ b/union_find/unionfind.py
@@ -59,7 +59,7 @@ class UnionFind(object):
     def count_groups(self):
         """ returns a count of the number of groups/sets in the
         data structure"""
-        return len(self.group.keys())
+        return len(self.group)
 
     def make_union(self, leadera, leaderb):
         """ takes union of two sets with leaders, leadera and leaderb


### PR DESCRIPTION
It is not necessary to form a list of keys to get size of dictionary.